### PR TITLE
bugfix/animations

### DIFF
--- a/src/engine/gamestate.c
+++ b/src/engine/gamestate.c
@@ -8,13 +8,14 @@ static TW_GameState* gameState = NULL;
 void TW_GameState_Create()
 {
     gameState = malloc( sizeof( TW_GameState ) );
-    gameState->delta_time = 0.0;
+    gameState->deltaTime = 0.0;
     gameState->now = 0;
     gameState->previous = 0;
     gameState->ms = SDL_GetTicks64();
     gameState->frame = 0;
     gameState->frameCap = 0;
     gameState->ticksPerFrame = 0;
+    gameState->paused = false;
 }
 
 
@@ -24,19 +25,19 @@ void TW_GameState_Update()
     gameState->ms = SDL_GetTicks64();
     gameState->frame++;
     gameState->now = SDL_GetPerformanceCounter();
-    gameState->delta_time = (float)( gameState->now - gameState->previous ) / (float)SDL_GetPerformanceFrequency();
-    if( gameState->delta_time >= TIME_DELTA_CAP )
+    gameState->deltaTime = (float)( gameState->now - gameState->previous ) / (float)SDL_GetPerformanceFrequency();
+    if( gameState->deltaTime >= TIME_DELTA_CAP )
     {
-        gameState->delta_time = 0.0;
+        gameState->deltaTime = 0.0;
     }
     gameState->previous = gameState->now;
 }
 
 
 // Get the current time delta.
-float TW_GameState_GetTimeDelta()
+float TW_GameState_GetDeltaTime()
 {
-    return gameState->delta_time;
+    return gameState->deltaTime;
 }
 
 
@@ -81,6 +82,27 @@ Uint64 TW_GameState_GetTime()
 }
 
 
+// Get the current pause status of the game.
+bool TW_GameState_PauseStatus()
+{
+    return gameState->paused;
+}
+
+
+// Pause the game.
+void TW_GameState_Pause()
+{
+    gameState->paused = true;
+}
+
+
+// Unpause/resume the game.
+void TW_GameState_Resume()
+{
+    gameState->paused = false;
+}
+
+
 // Free resources used by the game state.
 void TW_GameState_Free()
 {
@@ -88,6 +110,7 @@ void TW_GameState_Free()
     gameState->ms = 0;
     gameState->previous = 0;
     gameState->now = 0;
-    gameState->delta_time = 0.0;
+    gameState->deltaTime = 0.0;
+    gameState->paused = false;
     free( gameState );
 }

--- a/src/engine/gamestate.c
+++ b/src/engine/gamestate.c
@@ -76,6 +76,7 @@ void TW_GameState_LimitFrameRate()
 }
 
 
+// Get the current time in ms.
 Uint64 TW_GameState_GetTime()
 {
     return gameState->ms;

--- a/src/engine/gamestate.h
+++ b/src/engine/gamestate.h
@@ -72,6 +72,15 @@ void TW_GameState_LimitFrameRate();
 
 
 /**
+ * TW_GameState_GetTime - Get the current time in ms.
+ * 
+ * Returns:
+ * - Uint64         - The current time in ms.
+ */
+Uint64 TW_GameState_GetTime();
+
+
+/**
  * TW_GameState_PauseStatus - Get the current pause status of the game.
  * 
  * Returns:
@@ -90,9 +99,6 @@ void TW_GameState_Pause();
  * TW_GameState_Resume - Unpause/resume the game.
  */
 void TW_GameState_Resume();
-
-
-Uint64 TW_GameState_GetTime();
 
 
 /**

--- a/src/engine/gamestate.h
+++ b/src/engine/gamestate.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <SDL2/SDL.h>
+#include <stdbool.h>
 
 // Type definitions
 
@@ -10,13 +11,14 @@
 
 
 typedef struct TW_GameState {
-    float delta_time;
+    float deltaTime;
     Uint64 now;
     Uint64 previous;
     Uint64 ms;
     Uint64 frame;
     int frameCap;
     int ticksPerFrame;
+    bool paused;
 } TW_GameState;
 
 // Function definitions
@@ -35,13 +37,13 @@ void TW_GameState_Update();
 
 
 /**
- * TW_GameTimer_GetTimeDelta - Get the current time delta between now and the last time
+ * TW_GameState_GetDeltaTime - Get the current time delta between now and the last time
  *                             the game timer was updated.
  * 
  * Returns:
  * - float          - Time delta
  */
-float TW_GameState_GetTimeDelta();
+float TW_GameState_GetDeltaTime();
 
 
 /**
@@ -67,6 +69,27 @@ void TW_GameState_SetFrameLimit( int fps );
  *                               limit the frame rate.
  */
 void TW_GameState_LimitFrameRate();
+
+
+/**
+ * TW_GameState_PauseStatus - Get the current pause status of the game.
+ * 
+ * Returns:
+ * - bool           - true if paused, false if not
+ */
+bool TW_GameState_PauseStatus();
+
+
+/**
+ * TW_GameState_Pause - Pause the game.
+ */
+void TW_GameState_Pause();
+
+
+/**
+ * TW_GameState_Resume - Unpause/resume the game.
+ */
+void TW_GameState_Resume();
 
 
 Uint64 TW_GameState_GetTime();

--- a/src/game/debugstats.c
+++ b/src/game/debugstats.c
@@ -49,7 +49,7 @@ void TW_DebugStats_FPS_Think( TW_Component* component )
 
 void TW_DebugStats_DeltaTime_Think( TW_Component* component )
 {
-    snprintf( deltaTimeStatus, 50, "Delta Time: %.5f ms", TW_GameState_GetTimeDelta() );
+    snprintf( deltaTimeStatus, 50, "Delta Time: %.5f ms", TW_GameState_GetDeltaTime() );
     if( component->parent != NULL)
     {
         TW_Component* textComponent = TW_Entity_GetComponent( component->parent, TW_C_TEXT );

--- a/src/game/player.c
+++ b/src/game/player.c
@@ -1,6 +1,5 @@
 #include "player.h"
 
-// HERE BE SEGFAULTS
 
 void TW_Player_Think( TW_Component* component )
 {
@@ -35,21 +34,14 @@ void TW_Player_Think( TW_Component* component )
 
 TW_Entity* TW_Player_Create()
 {
-    // Create player entity
     TW_Entity* entityPlayer = TW_Entity_Create();
 
-    // Animations and sprites when called from here currently cause segfaults.
-    // Temporary sprite based player created.
-
-    // TW_Animation* gPlayer = TW_Animation_Create(
-    //     TW_Sprite_Create( "src/images/sprites/player.png", 32, 32 ), 4, (int[]){ 0, 1, 2, 3 }
-    // );
-
     TW_Sprite* spritePlayer = TW_Sprite_Create( "src/images/sprites/player.png", 32, 32 );
-    TW_Component* cPlayerSprite = TW_Component_Create( TW_C_SPRITE, spritePlayer );
-    TW_Entity_AddComponent( entityPlayer, cPlayerSprite );
+    TW_Animation* animationPlayer = TW_Animation_Create( spritePlayer, 4, (int[]){ 0, 1, 2, 3 } );
+    TW_Component* cPlayerAnimation = TW_Component_Create( TW_C_ANIMATION, animationPlayer );
+    TW_Entity_AddComponent( entityPlayer, cPlayerAnimation );
 
-    TW_Transform* transformPlayer = TW_Transform_Create( 100, 100, 0.0, 1.0 );
+    TW_Transform* transformPlayer = TW_Transform_Create( 230, 230, 0.0, 1.0 );
     TW_Component* cPlayerTransform = TW_Component_Create( TW_C_TRANSFORM, transformPlayer );
     TW_Entity_AddComponent( entityPlayer, cPlayerTransform );
 

--- a/src/main.c
+++ b/src/main.c
@@ -145,12 +145,6 @@ int main( int argc, char* args[] )
         TW_Scene_AddEntity( sceneMain, entityTitle );
 
         // Player Entity
-        // TW_Animation* gPlayer = TW_Animation_Create( TW_Sprite_Create( "src/images/sprites/player.png", 32, 32 ), 4, (int[]){ 0, 1, 2, 3 } );
-        // TW_Entity* entityPlayer = TW_Entity_Create();
-        // TW_Entity_AddComponent( entityPlayer, TW_Component_Create( TW_COMPONENT_ANIMATION, gPlayer ) );
-        // TW_Entity_AddComponent( entityPlayer, TW_Component_Create( TW_COMPONENT_TRANSFORM, TW_Transform_Create( 200, 200, 0.0, 1.0 ) ) );
-        // TW_Scene_AddEntity( sceneMain, entityPlayer );
-        // TW_Player_Create( sceneMain );
         TW_Scene_AddEntity( sceneMain, TW_Player_Create() );
 
         // Time

--- a/src/renderer/animation.c
+++ b/src/renderer/animation.c
@@ -42,7 +42,7 @@ void TW_Animation_Render( TW_Animation* self, TW_Transform* transform )
     TW_Sprite_Render( self->spriteSheet, transform );
     if( self->paused == false )
     {
-        self->timeSinceLastFrame = self->timeSinceLastFrame + TW_GameState_GetTimeDelta();
+        self->timeSinceLastFrame = self->timeSinceLastFrame + TW_GameState_GetDeltaTime();
         if( self->timeSinceLastFrame >= (float)self->animationSpeed / MILLISECONDS_IN_A_SEC )
         {
             self->timeSinceLastFrame = self->timeSinceLastFrame - (float)self->animationSpeed / MILLISECONDS_IN_A_SEC;

--- a/src/renderer/animation.c
+++ b/src/renderer/animation.c
@@ -2,20 +2,28 @@
 #include "../engine/gamestate.h"
 
 // Create an animation object from a sprite object
-TW_Animation* TW_Animation_Create( TW_Sprite* spriteSheet, int frameCount, int* animationFrames )
+TW_Animation* TW_Animation_Create( TW_Sprite* spriteSheet, int animationSize, int* animationFrames )
 {
     TW_Animation* animation = malloc( sizeof( TW_Animation ) );
 
     animation->spriteSheet = spriteSheet;
-    animation->frameCount = frameCount;
-    animation->animationFrames = animationFrames;
+    animation->animationSize = animationSize;
+
+    int* frameArray = malloc( animationSize * sizeof( int ) );
+    animation->animationFrames = frameArray;
+
+    for( int index = 0; index < animationSize; index++ )
+    {
+        animation->animationFrames[ index ] = animationFrames[ index ];
+    }
+
     animation->currentFrame = 0;
     animation->animationSpeed = 100;
     animation->timeSinceLastFrame = 0.0;
     animation->paused = false;
 
     // Checks
-    for( int frame = 0; frame < frameCount; frame++ )
+    for( int frame = 0; frame < animationSize; frame++ )
     {
         if( animation->animationFrames[ frame ] >= animation->spriteSheet->gridSize )
         {
@@ -28,7 +36,7 @@ TW_Animation* TW_Animation_Create( TW_Sprite* spriteSheet, int frameCount, int* 
         }
     }
 
-    animation->spriteSheet->parent = animation;
+    // animation->spriteSheet->parent = animation;
     animation->parent = NULL;
 
     return animation;
@@ -46,7 +54,7 @@ void TW_Animation_Render( TW_Animation* self, TW_Transform* transform )
         if( self->timeSinceLastFrame >= (float)self->animationSpeed / MILLISECONDS_IN_A_SEC )
         {
             self->timeSinceLastFrame = self->timeSinceLastFrame - (float)self->animationSpeed / MILLISECONDS_IN_A_SEC;
-            self->currentFrame = ( self->currentFrame + 1 ) % self->frameCount;
+            self->currentFrame = ( self->currentFrame + 1 ) % self->animationSize;
         }
     }
 }
@@ -58,11 +66,12 @@ void TW_Animation_Free( TW_Animation* self )
     self->paused = false;
     self->animationSpeed = 0;
     self->currentFrame = 0;
-    for( int index = 0; index < self->frameCount; index++ )
+    for( int index = 0; index < self->animationSize; index++ )
     {
         self->animationFrames[ index ] = 0;
     }
-    self->frameCount = 0;
+    free( self->animationFrames );
+    self->animationSize = 0;
     TW_Sprite_Free( self->spriteSheet );
     free( self );
 }

--- a/src/renderer/animation.h
+++ b/src/renderer/animation.h
@@ -25,7 +25,7 @@ typedef struct TW_Component TW_Component;
  */
 typedef struct TW_Animation {
     TW_Sprite* spriteSheet;     // The sprite object with all the texture information
-    int frameCount;             // Number of frames in the animation
+    int animationSize;          // Number of frames in the animation
     int* animationFrames;       // Sprite frames that form part of the animation
     int currentFrame;           // The current frame of the animation
     int animationSpeed;         // Speed of the animation


### PR DESCRIPTION
Animation components when called from outside the main loop cause segmentation faults, appears at first glance that the memory region associated with the `TW_Animation->currentFrame` is to blame... investigate and fix.